### PR TITLE
Criando as api's insert e delete para refeições completas, e Corrigindo problemas de log.

### DIFF
--- a/src/cadastro_alimentar/controller/pesos_alimentos.clj
+++ b/src/cadastro_alimentar/controller/pesos_alimentos.clj
@@ -19,6 +19,15 @@
     (if (> (count result) 0)
       result
       (throw (Exception. (str "INSERT - Erro ao criar peso-alimento: " result))))))
+
+(defn delete-by-refeicao
+  [refeicao-uuid]
+  (if (= (count (by-refeicao refeicao-uuid)) 0)
+    (throw (Exception. (str "refeicao nao encontrada em pesos-alimentos: " refeicao-uuid)))
+    (do
+      (db.pesos-alimentos/delete-by-refeicao refeicao-uuid)
+      (log/info "DELETE - alimento deletado: " refeicao-uuid)
+      true)))
       
 (defn create-pesos-alimentos-by-list
   [pesos-alimentos]

--- a/src/cadastro_alimentar/controller/refeicoes.clj
+++ b/src/cadastro_alimentar/controller/refeicoes.clj
@@ -73,6 +73,9 @@
   (if (= (count (by-uuid refeicao-uuid)) 0)
     (throw (Exception. (str "refeicao nao encontrado: " refeicao-uuid)))
     (do
+      (let [pesos-alimentos (controller.pesos-alimentos/by-refeicao refeicao-uuid)]
+        (if (> (count pesos-alimentos) 0)
+          (controller.pesos-alimentos/delete-by-refeicao refeicao-uuid)))
       (db.refeicoes/delete-by-uuid refeicao-uuid)
       (log/info "DELETE - refeicao deletado: " refeicao-uuid)
       true)))
@@ -109,6 +112,7 @@
   [complete-refeicao]
   (if (logic.refeicoes/valid? complete-refeicao)
     (do
+      (log/info "-- refeicao-completa aceita --")
       (let [refeicao-builder (logic.refeicoes/build-refeicao (:refeicao complete-refeicao))
             pesos-alimentos-builder (logic.pesos-alimentos/build-pesos-alimentos (:alimentos complete-refeicao) (:uuid refeicao-builder))
             refeicao-inserted (create-refeicao refeicao-builder)

--- a/src/cadastro_alimentar/handler.clj
+++ b/src/cadastro_alimentar/handler.clj
@@ -54,8 +54,7 @@
   [uuid]
   (try 
     (if (controller.alimentos/delete-by-uuid uuid)
-      (ok)
-      (not-found))
+      (ok))
     (catch Exception e (do
                           (log/error e)
                           (not-found)))))
@@ -80,6 +79,28 @@
     (if (= (count result) 0)
       (not-found)
       result)))
+
+(defn refeicao-completa-insert
+  [body]
+  (try 
+    (let [result (controller.refeicoes/insert-complete-refeicao body)]
+      (if (= (count result) 2)
+        (-> {}
+            (assoc :status 200)
+            (assoc :body result))
+        (bad-request)))
+    (catch Exception e (do
+                          (log/error e)
+                          (conflict)))))
+
+(defn refeicao-delete-by-refeicao-uuid
+  [refeicao-uuid]
+  (try 
+    (if (controller.refeicoes/delete-by-uuid refeicao-uuid)
+      (ok))
+    (catch Exception e (do
+                          (log/error e)
+                          (not-found)))))
 
 (defn tipos-alimentos-get-all
   []
@@ -140,7 +161,9 @@
     (context "/refeicoes" []
       (GET "/" [] (refeicoes-get-all))
       (GET "/:uuid" [uuid] (refeicoes-get-by-uuid uuid))
-      (GET "/completas/:date" [date] (refeicoes-get-all-refeicoes-by-date-with-calculated-macros date)))
+      (GET "/completas/:date" [date] (refeicoes-get-all-refeicoes-by-date-with-calculated-macros date))
+      (POST "/completas" {:keys [body]} (refeicao-completa-insert body))
+      (DELETE "/completas/:uuid" [uuid] (refeicao-delete-by-refeicao-uuid uuid)))
     
     (context "/tipos_alimentos" []
       (GET "/" [] (tipos-alimentos-get-all))
@@ -162,13 +185,13 @@
     (try (handler request)
           (catch Exception e
             (do
-              (log/error (.getMessage e))
+              ;(log/error (.getMessage e))
               {:status 400
                :body (.getMessage e)})))))
             
 
 (def app
   (-> app-routes
-      (wrap-exception)
+      ;(wrap-exception)
       (wrap-json-response)
       (wrap-json-body {:keywords? true})))

--- a/src/cadastro_alimentar/logic/refeicoes.clj
+++ b/src/cadastro_alimentar/logic/refeicoes.clj
@@ -1,6 +1,7 @@
 (ns cadastro-alimentar.logic.refeicoes
   (:require [cadastro-alimentar.utils.uuids :refer [uuid uuid-from-string]]
-            [cadastro-alimentar.utils.dates :refer [now str->date]]))
+            [cadastro-alimentar.utils.dates :refer [now str->date]]
+            [clojure.tools.logging :as log]))
 
 (defn build-refeicao
   [refeicao]
@@ -30,9 +31,10 @@
                               (assoc :uuid (:alimento_uuid %)))
                       pesos-alimentos-inserted))]
     (-> {}
-        (assoc :alimentos alimentos)
+        (assoc :alimentos (apply list alimentos))
         (assoc :refeicao (first refeicao-inserted)))))
 
 (defn valid?
   [complete-refeicao]
-  (and (list? (:alimentos complete-refeicao)) (not (nil? (:refeicao complete-refeicao)))))
+  (log/info "[complete-refeicao/valid?]: list? <<" (list? (apply list (:alimentos complete-refeicao))) ">> and not-nil? <<" (not (nil? (:refeicao complete-refeicao))) ">>")
+  (and (list? (apply list (:alimentos complete-refeicao))) (not (nil? (:refeicao complete-refeicao)))))

--- a/test/cadastro_alimentar/controller_test.clj
+++ b/test/cadastro_alimentar/controller_test.clj
@@ -110,9 +110,10 @@
             refeicoes (:refeicoes (first result))]
         (is (= (count refeicoes) 4))
         (is (= (str (:kcal calculated-macros)) "0.033737760000000006"))
-        (is (= (str (:peso calculated-macros)) "570.0")))
-          
-      )))
+        (is (= (str (:peso calculated-macros)) "570.0")))))
+
+  (testing "shoul delete a refeicao and yours pesos-alimentos by refeicao-uuid"
+    (is (= (controller.refeicoes/delete-by-uuid "d6e3ccca-cb0f-4fa4-a0ea-92576407f998")))))
 
 (deftest testing-alimentos
   (testing "should create a alimento"


### PR DESCRIPTION
#13 
- Não existia o endpoint para fazer a inserção da refeição completa
- Vale observar que a estrutura do json deverá ser:
```
{
    "alimentos": [
        {
            "uuid": "33e1b120-01a2-47f6-b088-532de50fdb22",
            "peso": 100.0
        }
    ],
    "refeicao": {
        "descricao": "Almoço"
    }
}
```
