### PR TITLE
[IMPROVEMENT] mokando banco de dados nos teste dos alimentos (#19)

### DIFF
--- a/src/cadastro_alimentar/controller/alimentos.clj
+++ b/src/cadastro_alimentar/controller/alimentos.clj
@@ -16,7 +16,7 @@
 
 (defn by-uuid
   [uuid]
-  (let [result  (db.alimentos/by-uuid uuid)]
+  (let [result (db.alimentos/by-uuid uuid)]
     (if (= (count result) 0)
       ()
       (do

--- a/src/cadastro_alimentar/db/alimentos.clj
+++ b/src/cadastro_alimentar/db/alimentos.clj
@@ -10,7 +10,7 @@
 (defn get
   [clauses]
   (select e/alimentos
-    (fields :uuid :nome :peso [:qtde_carboidrato :qtde-carboidrato] [:qtde_gorduras :qtde-gordduras] [:qtde_proteinas :qtde-proteinas] [:tipo_alimento_uuid :tipo-alimento-uuid]
+    (fields :uuid :nome :peso [:qtde_carboidrato :qtde-carboidrato] [:qtde_gorduras :qtde-gorduras] [:qtde_proteinas :qtde-proteinas] [:tipo_alimento_uuid :tipo-alimento-uuid]
             [:tipos.descricao :tipo-alimento-descricao])
 
     (join :inner [e/tipos-alimentos :tipos] (= :alimentos.tipo_alimento_uuid :tipos.uuid))

--- a/src/cadastro_alimentar/mocks/alimentos.clj
+++ b/src/cadastro_alimentar/mocks/alimentos.clj
@@ -1,0 +1,38 @@
+(ns cadastro-alimentar.mocks.alimentos)
+
+(def mock-database-alimentos-get {:uuid "ff272397-2999-4896-9dda-4545c5ab4f33" :nome "Alimento Teste Mockado" :peso 1.0 :qtde-carboidrato 0.281 :qtde-gorduras 0.002	:qtde-proteinas 0.025	:tipo-alimento-uuid "f1fd8177-d95c-47e7-ae69-6ad6ec8f48c2" :tipo-alimento-descricao "Alimento Teste"})
+(def mock-database-alimentos-updated {:uuid "ff272397-2999-4896-9dda-4545c5ab4f33" :nome "Alimento Cozido Teste Update" :peso 1.0 :qtde-carboidrato 0.281 :qtde-gorduras 0.002	:qtde-proteinas 0.5	:tipo-alimento-uuid "5e684cd9-ab77-4bcb-96f5-a3e46d82c454" :tipo-alimento-descricao "Alimento Teste Updated"})
+(def mock-database-alimentos-insert-exists {:uuid "ada049ae-e92c-4795-b359-c84345ffa1bb" :nome "Alimento Teste Cozido" :peso 1.0 :qtde-carboidrato 0.281 :qtde-gorduras 0.002	:qtde-proteinas 0.025	:tipo-alimento-uuid "f1fd8177-d95c-47e7-ae69-6ad6ec8f48c2" :tipo-alimento-descricao "Alimento Teste"})
+
+(defn mock-db-alimentos-get
+  [clauses]
+  (-> mock-database-alimentos-get (list)))
+
+(defn mock-db-alimentos-get-not-exist
+  [clauses]
+  ())
+
+(defn mock-db-alimentos-get-for-insert
+  [clauses]
+  ())
+
+(defn mock-db-alimentos-get-for-update
+  [clauses]
+  (-> mock-database-alimentos-updated (list)))
+
+(defn mock-db-alimentos-get-for-update-not-exist
+  [clauses]
+  ())
+  
+(defn mock-db-alimentos-get-for-delete-not-exist
+  [clauses]
+  ())
+
+(defn mock-db-alimentos-insert!
+  [alimento])
+
+(defn mock-db-alimentos-update!
+  [fields clauses])
+
+(defn mock-db-alimentos-delete-by-uuid
+  [alimento-uuid])

--- a/src/cadastro_alimentar/mocks/pesos_alimentos.clj
+++ b/src/cadastro_alimentar/mocks/pesos_alimentos.clj
@@ -1,0 +1,47 @@
+(ns cadastro-alimentar.mocks.pesos-alimentos)
+
+(defn- mock-now []
+  "2020-07-24T15:53:07Z")
+
+(def mock-database-pesos-alimentos-get {:peso 100.2 :alimento_uuid "ff272397-2999-4896-9dda-4545c5ab4f33" :refeicao_uuid "c8a2bfb9-2828-4c70-84ce-b2c3dd3db230"})
+(def mock-database-pesos-alimentos-get-by-list (list {:peso 100.2 :alimento_uuid "ff272397-2999-4896-9dda-4545c5ab4f33" :refeicao_uuid "d6e3ccca-cb0f-4fa4-a0ea-92576407f998"}
+                                                     {:peso 100.2 :alimento_uuid "ff272397-2999-4896-9dda-4545c5ab4f33" :refeicao_uuid "d6e3ccca-cb0f-4fa4-a0ea-92576407f998"}
+                                                     {:peso 100.2 :alimento_uuid "ff272397-2999-4896-9dda-4545c5ab4f33" :refeicao_uuid "d6e3ccca-cb0f-4fa4-a0ea-92576407f998"}
+                                                     {:peso 100.2 :alimento_uuid "ff272397-2999-4896-9dda-4545c5ab4f33" :refeicao_uuid "d6e3ccca-cb0f-4fa4-a0ea-92576407f998"}))
+
+(defn mock-db-pesos-alimentos-get
+  [clauses]
+  (-> mock-database-pesos-alimentos-get (list)))
+
+(defn mock-db-pesos-alimentos-get-by-refeicao-uuid
+  [refeicao-uuid]
+  (-> mock-database-pesos-alimentos-get (list)))
+
+(defn mock-db-pesos-alimentos-get-not-exist
+  [clauses]
+  ())
+
+(defn mock-db-pesos-alimentos-get-by-refeicao-uuid-not-exist
+  [refeicao-uuid]
+  ())
+
+(defn mock-db-pesos-alimentos-get-for-update-not-exist
+  [clauses]
+  ())
+  
+(defn mock-db-pesos-alimentos-get-for-delete-not-exist
+  [clauses]
+  ())
+
+(defn mock-db-pesos-alimentos-insert!
+  [peso-alimento])
+
+(defn mock-db-pesos-alimentos-update!
+  [fields clauses])
+
+(defn mock-db-pesos-alimentos-delete-by-refeicao
+  [refeicao-uuid])
+
+(defn mock-create-peso-alimentos-by-list
+  [pesos-alimentos]
+  mock-database-pesos-alimentos-get-by-list)

--- a/src/cadastro_alimentar/mocks/refeicoes.clj
+++ b/src/cadastro_alimentar/mocks/refeicoes.clj
@@ -1,0 +1,88 @@
+(ns cadastro-alimentar.mocks.refeicoes
+  (:require [cadastro-alimentar.utils.dates :refer [str->date]]))
+
+(defn- mock-now []
+  "2020-07-24T15:53:07Z")
+
+(def mock-database-refeicoes-get {:uuid "c8a2bfb9-2828-4c70-84ce-b2c3dd3db230" :moment (mock-now) :descricao "Refeicao Teste"})
+(def mock-database-refeicoes-updated {:uuid "c8a2bfb9-2828-4c70-84ce-b2c3dd3db230" :moment (mock-now) :descricao "Refeicao Teste Updated"})
+
+(defn mock-db-refeicoes-get
+  [clauses]
+  (-> mock-database-refeicoes-get (list)))
+
+(defn mock-db-refeicoes-get-not-exist
+  [clauses]
+  ())
+
+(defn mock-db-refeicoes-get-for-insert
+  [clauses]
+  ())
+
+(defn mock-db-refeicoes-get-for-update
+  [clauses]
+  (-> mock-database-refeicoes-updated (list)))
+
+(defn mock-db-refeicoes-get-for-update-not-exist
+  [clauses]
+  ())
+  
+(defn mock-db-refeicoes-get-for-delete-not-exist
+  [clauses]
+  ())
+
+(defn mock-db-refeicoes-insert!
+  [refeicao])
+
+(defn mock-db-refeicoes-update!
+  [fields clauses])
+
+(defn mock-db-refeicoes-delete-by-uuid
+  [refeicao-uuid])
+
+(defn mock-db-refeicoes-get-all-refecoes-by-date
+  [date]
+  (list (-> {}
+          (assoc :refeicao-uuid "c8a2bfb9-2828-4c70-84ce-b2c3dd3db230")
+          (assoc :moment (mock-now))
+          (assoc :refeicaoes-descricao nil) 
+          (assoc :peso 300.0)
+          (assoc :nome "Feijão Carioca Cozido")
+          (assoc :peso-unitario 1.0)
+          (assoc :qtde-carbo 0.136)
+          (assoc :qtde-prot 0.048)
+          (assoc :qtde-gordura 0.005)
+          (assoc :tipos-descricao "Grão/Cereal"))
+      (-> {}
+          (assoc :refeicao-uuid "c8a2bfb9-2828-4c70-84ce-b2c3dd3db230")
+          (assoc :moment (mock-now))
+          (assoc :refeicaoes-descricao nil) 
+          (assoc :peso 200.0)
+          (assoc :nome "Arroz Branco Cozido")
+          (assoc :peso-unitario 1.0)
+          (assoc :qtde-carbo 0.281)
+          (assoc :qtde-prot 0.025)
+          (assoc :qtde-gordura 0.002)
+          (assoc :tipos-descricao "Grão/Cereal"))
+      (-> {}
+          (assoc :refeicao-uuid "c8a2bfb9-2828-4c70-84ce-b2c3dd3db230")
+          (assoc :moment (mock-now))
+          (assoc :refeicaoes-descricao nil) 
+          (assoc :peso 400.0)
+          (assoc :nome "Frango Refogado")
+          (assoc :peso-unitario 1.0)
+          (assoc :qtde-carbo 0.0)
+          (assoc :qtde-prot 0.315)
+          (assoc :qtde-gordura 0.022)
+          (assoc :tipos-descricao "Carne de Frango"))
+      (-> {}
+          (assoc :refeicao-uuid "c8a2bfb9-2828-4c70-84ce-b2c3dd3db230")
+          (assoc :moment (mock-now))
+          (assoc :refeicaoes-descricao nil) 
+          (assoc :peso 50.0)
+          (assoc :nome "Creme de Avelã")
+          (assoc :peso-unitario 50.0)
+          (assoc :qtde-carbo 0.48)
+          (assoc :qtde-prot 0.05)
+          (assoc :qtde-gordura 0.42)
+          (assoc :tipos-descricao "Oleonígeno"))))

--- a/src/cadastro_alimentar/mocks/tipos_alimentos.clj
+++ b/src/cadastro_alimentar/mocks/tipos_alimentos.clj
@@ -1,0 +1,40 @@
+(ns cadastro-alimentar.mocks.tipos-alimentos)
+
+(def mock-database-tipos-alimentos-get {:uuid "a3770a85-eb2a-4994-8502-fa8ebaea9fa3" :descricao "Alimento Teste"})
+(def mock-database-tipos-alimentos-updated {:uuid "a3770a85-eb2a-4994-8502-fa8ebaea9fa3" :descricao "Tipo Alimento Update"})
+
+(defn mock-db-tipos-alimentos-get
+  [clauses]
+  (-> mock-database-tipos-alimentos-get (list)))
+
+(defn mock-db-tipos-alimentos-get-not-exist
+  [clauses]
+  ())
+
+(defn mock-db-alimentipos-alimentos-get-for-insert
+  [clauses]
+  ())
+
+(defn mock-db-tipos-alimentos-get-for-update
+  [clauses]
+  (-> mock-database-tipos-alimentos-updated (list)))
+
+(defn mock-db-tipos-alimentos-get-for-update-not-exist
+  [clauses]
+  ())
+  
+(defn mock-db-tipos-alimentos-get-for-delete-not-exist
+  [clauses]
+  ())
+
+(defn mock-db-tipos-alimentos-insert!
+  [tipo-alimento])
+
+(defn mock-db-tipos-alimentos-update!
+  [fields clauses])
+
+(defn mock-db-tipos-alimentos-delete-by-uuid
+  [tipo-alimento-uuid])
+
+(defn mock-db-tipos-alimentos-delete-by-descricao
+  [descricao])

--- a/test/cadastro_alimentar/controller_test.clj
+++ b/test/cadastro_alimentar/controller_test.clj
@@ -5,7 +5,16 @@
             [cadastro-alimentar.controller.alimentos :as controller.alimentos]
             [cadastro-alimentar.controller.tipos-alimentos :as controller.tipos-alimentos]
             [cadastro-alimentar.utils.dates :as utils.dates]
-            [cadastro-alimentar.utils.uuids :as utils.uuids]))
+            [cadastro-alimentar.utils.uuids :as utils.uuids]
+            [cadastro-alimentar.db.alimentos :as db.alimentos]
+            [cadastro-alimentar.mocks.alimentos :as mock.alimentos]
+            [cadastro-alimentar.db.refeicoes :as db.refeicoes]
+            [cadastro-alimentar.mocks.refeicoes :as mock.refeicoes]
+            [cadastro-alimentar.db.tipos-alimentos :as db.tipos-alimentos]
+            [cadastro-alimentar.mocks.tipos-alimentos :as mock.tipos-alimentos]
+            [cadastro-alimentar.db.pesos-alimentos :as db.pesos-alimentos]
+            [cadastro-alimentar.mocks.pesos-alimentos :as mock.pesos-alimentos]
+            [cadastro-alimentar.controller.pesos-alimentos :as controller.pesos-alimentos]))
 
 (def tipo-alimento-teste {:uuid "6c7ef568-be99-4093-a3a6-ecfcfe13fd3a" :descricao "Alimento Teste"})
 (def refeicao-teste {:uuid "1478fa0b-d996-489e-a1f0-649b0d28d7ee" :descricao "refeicao teste unitario"})
@@ -19,125 +28,184 @@
 
 (deftest should-calculate-macros 
   (testing "should calculate macros based in information of refeicoes"
-    (let [refeicoes (controller.refeicoes/get-all-refeicoes-by-date-with-calculated-macros "2020-07-24")]
-      (is (= (count (:refeicoes (first refeicoes))) 5))
-      (is (= (:date (first refeicoes)) (utils.dates/str->date "2020-07-24"))))))
+    (with-redefs [db.refeicoes/get (fn [clauses] (mock.refeicoes/mock-db-refeicoes-get clauses))
+                  db.refeicoes/insert! (fn [refeicao-builder] (mock.refeicoes/mock-db-refeicoes-get-for-insert refeicao-builder))
+                  db.pesos-alimentos/insert! (fn [peso-alimento] (mock.pesos-alimentos/mock-db-pesos-alimentos-insert! peso-alimento))
+                  db.refeicoes/get-all-refeicoes-by-date (fn [date] (mock.refeicoes/mock-db-refeicoes-get-all-refecoes-by-date date))]
+      (let [refeicoes (controller.refeicoes/get-all-refeicoes-by-date-with-calculated-macros "2020-07-24")]
+        (is (= (count (:refeicoes (first refeicoes))) 4))
+        (is (= (:date (first refeicoes)) (utils.dates/str->date "2020-07-24")))))))
 
 (deftest testing-alimentos
   (testing "should calculate macros based in information of refeicoes"
-    (let [alimento (first (controller.alimentos/by-uuid "1864c9a4-2dac-48d6-9a9f-12cc91b1cb50"))]
-      (is (= (str (:uuid alimento)) "1864c9a4-2dac-48d6-9a9f-12cc91b1cb50")))))
+    (with-redefs [db.alimentos/get (fn [clauses] (mock.alimentos/mock-db-alimentos-get clauses))]
+      (let [alimento (first (controller.alimentos/by-uuid "ff272397-2999-4896-9dda-4545c5ab4f33"))]
+        (is (= (str (:uuid alimento)) "ff272397-2999-4896-9dda-4545c5ab4f33")))))
+        
+  (testing "should create a alimento"
+    (with-redefs [db.alimentos/get (fn [clauses] (mock.alimentos/mock-db-alimentos-get-for-insert clauses))
+                  db.alimentos/insert! (fn [alimento] (mock.alimentos/mock-db-alimentos-insert! alimento))]
+      (let [alimento (controller.alimentos/create-alimento alimento-teste)]
+        (is (= (count alimento) 1)))))
+              
+  (testing "should not create a alimento when if not exists"
+    (with-redefs [db.alimentos/get (fn [clauses] (mock.alimentos/mock-db-alimentos-get clauses))
+                  db.alimentos/insert! (fn [alimento] (mock.alimentos/mock-db-alimentos-insert! alimento))]
+      (is (thrown-with-msg? Exception #"alimento ja existe: 31dbcee6-9e58-4ee8-ab52-d0d2e5d9d3d8" (:processed (controller.alimentos/create-alimento alimento-teste))))))
+          
+  (testing "should update a alimento"
+    (with-redefs [db.alimentos/get (fn [clauses] (mock.alimentos/mock-db-alimentos-get-for-update clauses))
+                  db.alimentos/update! (fn [fields clauses] (mock.alimentos/mock-db-alimentos-update! fields clauses))]
+      (let [result (controller.alimentos/update-alimento (:uuid alimento-teste) {:nome "Alimento Cozido Teste Update" :qtde-carboidrato 0.281 :qtde-gorduras 0.222 :qtde-proteinas 0.5})]
+        (is (= (count result) 1))
+        (is (= (:nome (first result)) "Alimento Cozido Teste Update"))
+        (is (= (:qtde-carboidrato (first result))  0.281))
+        (is (= (:qtde-gorduras (first result)) 0.002))
+        (is (= (:qtde-proteinas (first result)) 0.5)))))
+
+  (testing "should not update alimento when it not exists"
+    (with-redefs [db.alimentos/get (fn [clauses] (mock.alimentos/mock-db-alimentos-get-for-update-not-exist clauses))
+                  db.alimentos/update! (fn [fields clauses] (mock.alimentos/mock-db-alimentos-update! fields clauses))]
+      (is (thrown-with-msg? Exception #"UPDATE - alimento nao encontrado: d9619362-b603-4b2f-8c9c-9ff5f2c70478" 
+                            (controller.alimentos/update-alimento "d9619362-b603-4b2f-8c9c-9ff5f2c70478" 
+                                                                  {:nome "alimento teste update" :qtde-carboidrato 0.555 :qtde-gorduras 0.222 :qtde-proteinas 0.1})))))
+
+  (testing "should delete a alimento by uuid"
+    (with-redefs [db.alimentos/get (fn [clauses] (mock.alimentos/mock-db-alimentos-get clauses))
+                  db.alimentos/delete-by-uuid (fn [alimento-uuid] (mock.alimentos/mock-db-alimentos-delete-by-uuid alimento-uuid))]
+      (is (= (controller.alimentos/delete-by-uuid (:uuid alimento-teste))))))
+
+  (testing "should not delete a alimento by uuid when it not exists"
+    (with-redefs [db.alimentos/get (fn [clauses] (mock.alimentos/mock-db-alimentos-get-for-delete-not-exist clauses))
+                  db.alimentos/delete-by-uuid (fn [alimento-uuid] (mock.alimentos/mock-db-alimentos-delete-by-uuid alimento-uuid))]
+      (is (thrown-with-msg? Exception #"alimento nao encontrado: 31dbcee6-9e58-4ee8-ab52-d0d2e5d9d3d8" (:processed (controller.alimentos/delete-by-uuid (:uuid alimento-teste))))))))
 
 (deftest testing-tipo-alimento
   (testing "should create a tipo-alimento"
-    (let [tipo-alimento (first (controller.tipos-alimentos/create-tipo-alimento tipo-alimento-teste))
-          tipo-alimento-saved (controller.tipos-alimentos/by-descricao "Alimento Teste")]
-      (is (= (str (:descricao tipo-alimento-saved) "Alimento Teste")))
-      (is (= (str (:descricao tipo-alimento) "Alimento Teste")))
-      (is (= (str (:uuid tipo-alimento-saved) "6c7ef568-be99-4093-a3a6-ecfcfe13fd3a")))
-      (is (= (str (:uuid tipo-alimento)) "6c7ef568-be99-4093-a3a6-ecfcfe13fd3a"))))
+    (with-redefs [db.tipos-alimentos/get (fn [clauses] (mock.tipos-alimentos/mock-db-alimentipos-alimentos-get-for-insert clauses))
+                  db.tipos-alimentos/insert! (fn [tipo-alimento] (mock.tipos-alimentos/mock-db-tipos-alimentos-insert! tipo-alimento))]
+      (let [tipo-alimento (first (controller.tipos-alimentos/create-tipo-alimento tipo-alimento-teste))
+            tipo-alimento-saved (controller.tipos-alimentos/by-descricao "Alimento Teste")]
+        (is (= (str (:descricao tipo-alimento-saved) "Alimento Teste")))
+        (is (= (str (:descricao tipo-alimento) "Alimento Teste")))
+        (is (= (str (:uuid tipo-alimento-saved) "6c7ef568-be99-4093-a3a6-ecfcfe13fd3a")))
+        (is (= (str (:uuid tipo-alimento)) "6c7ef568-be99-4093-a3a6-ecfcfe13fd3a")))))
 
   (testing "should not create a tipo-alimento when it exists"
-      (is (thrown-with-msg? Exception #"tipo-alimento ja existe: Alimento Teste" (:processed (controller.tipos-alimentos/create-tipo-alimento tipo-alimento-teste)))))
+    (with-redefs [db.tipos-alimentos/get (fn [clauses] (mock.tipos-alimentos/mock-db-tipos-alimentos-get clauses))
+                  db.tipos-alimentos/insert! (fn [tipo-alimento] (mock.tipos-alimentos/mock-db-tipos-alimentos-insert! tipo-alimento))]
+      (is (thrown-with-msg? Exception #"tipo-alimento ja existe: Alimento Teste" (:processed (controller.tipos-alimentos/create-tipo-alimento tipo-alimento-teste))))))
 
   (testing "should update a tipo-alimento"
-    (let [tipo-alimento (-> {}
-                            (assoc :uuid (:uuid tipo-alimento-teste))
-                            (assoc :descricao "Alimento Teste Update"))]
-      (controller.tipos-alimentos/update-tipo-alimento (:uuid tipo-alimento-teste) 
-                                                       {:descricao "tipo alimento teste update"})
-      (let [tipo-alimento-saved (controller.tipos-alimentos/by-descricao "Alimento Teste Update")]
-        (is (= (str (:descricao tipo-alimento-saved) "Alimento Teste Update"))))))
+    (with-redefs [db.tipos-alimentos/get (fn [clauses] (mock.tipos-alimentos/mock-db-tipos-alimentos-get-for-update clauses))
+                  db.tipos-alimentos/update! (fn [fields clauses] (mock.tipos-alimentos/mock-db-tipos-alimentos-update! fields clauses))]
+      (let [tipo-alimento (-> {}
+                              (assoc :uuid (:uuid tipo-alimento-teste))
+                              (assoc :descricao "Alimento Teste Update"))]
+        (controller.tipos-alimentos/update-tipo-alimento (:uuid tipo-alimento-teste) 
+                                                        {:descricao "tipo alimento teste update"})
+        (let [tipo-alimento-saved (controller.tipos-alimentos/by-descricao "Alimento Teste Update")]
+          (is (= (str (:descricao tipo-alimento-saved) "Alimento Teste Update")))))))
       
 
   (testing "should not update a tipo-alimento when not it exists"
+    (with-redefs [db.tipos-alimentos/get (fn [clauses] (mock.tipos-alimentos/mock-db-tipos-alimentos-get-not-exist clauses))
+                  db.tipos-alimentos/insert! (fn [tipo-alimento] (mock.tipos-alimentos/mock-db-tipos-alimentos-insert! tipo-alimento))]
       (is (thrown-with-msg? Exception #"tipo-alimento nao encontrado: tipo alimento teste update" (:processed (controller.tipos-alimentos/update-tipo-alimento "3158db7c-9f7f-4857-aa0c-3afc2ee35520" 
-                                                                                                                                                    {:descricao "tipo alimento teste update"})))))
-      
-  (testing "should not delete a tipo-alimento by descricao"
-    (is (= (controller.tipos-alimentos/delete-by-descricao "tipo alimento teste update"))))
+                                                                                                                                                    {:descricao "tipo alimento teste update"}))))))
+  (testing "should delete a tipo-alimento by descricao"
+    (with-redefs [db.tipos-alimentos/get (fn [clauses] (mock.tipos-alimentos/mock-db-tipos-alimentos-get clauses))
+                  db.tipos-alimentos/delete-by-descricao (fn [descricao] (mock.tipos-alimentos/mock-db-tipos-alimentos-delete-by-descricao descricao))]
+      (is (= (controller.tipos-alimentos/delete-by-descricao "tipo alimento teste update")))))
 
   (testing "should not delete a tipo-alimento by descricao when it not exists"
-    (is (thrown-with-msg? Exception #"tipo-alimento nao encontrado: tipo alimento teste update" (:processed (controller.tipos-alimentos/delete-by-descricao "tipo alimento teste update")))))
+    (with-redefs [db.tipos-alimentos/get (fn [clauses] (mock.tipos-alimentos/mock-db-tipos-alimentos-get-not-exist clauses))
+                  db.tipos-alimentos/delete-by-descricao (fn [descricao] (mock.tipos-alimentos/mock-db-tipos-alimentos-delete-by-descricao descricao))]
+      (is (thrown-with-msg? Exception #"tipo-alimento nao encontrado: tipo alimento teste update" (:processed (controller.tipos-alimentos/delete-by-descricao "tipo alimento teste update"))))))
     
   (testing "should delete tipo-alimento by uuid"
-    (let [tipo-alimento-created (controller.tipos-alimentos/create-tipo-alimento tipo-alimento-teste)]
+    (with-redefs [db.tipos-alimentos/get (fn [clauses] (mock.tipos-alimentos/mock-db-tipos-alimentos-get clauses))
+                  db.tipos-alimentos/delete-by-uuid (fn [tipo-alimento-uuid] (mock.tipos-alimentos/mock-db-tipos-alimentos-delete-by-uuid tipo-alimento-uuid))]
       (is (controller.tipos-alimentos/delete-by-uuid "6c7ef568-be99-4093-a3a6-ecfcfe13fd3a"))))
       
   (testing "should not delete a tipo-alimento by uuid when it not exists"
-    (is (thrown-with-msg? Exception #"tipo-alimento nao encontrado: 6c7ef568-be99-4093-a3a6-ecfcfe13fd3a" (:processed (controller.tipos-alimentos/delete-by-descricao "6c7ef568-be99-4093-a3a6-ecfcfe13fd3a"))))))
+    (with-redefs [db.tipos-alimentos/get (fn [clauses] (mock.tipos-alimentos/mock-db-tipos-alimentos-get-not-exist clauses))
+                  db.tipos-alimentos/delete-by-uuid (fn [tipo-alimento-uuid] (mock.tipos-alimentos/mock-db-tipos-alimentos-delete-by-uuid tipo-alimento-uuid))]
+    (is (thrown-with-msg? Exception #"tipo-alimento nao encontrado: 6c7ef568-be99-4093-a3a6-ecfcfe13fd3a" (:processed (controller.tipos-alimentos/delete-by-descricao "6c7ef568-be99-4093-a3a6-ecfcfe13fd3a")))))))
 
 (deftest testing-refeicoes
   (testing "should create a refeicao"
+    (with-redefs [db.refeicoes/get (fn [clauses] (mock.refeicoes/mock-db-refeicoes-get-not-exist clauses))
+                  db.refeicoes/insert! (fn [refeicao-builder] (mock.refeicoes/mock-db-refeicoes-get-for-insert refeicao-builder))]
     (let [refeicao (controller.refeicoes/create-refeicao refeicao-teste)]
-      (is (= (count refeicao) 1))))
+      (is (= (count refeicao) 1)))))
       
   (testing "should not create a refeicao when it exists"
-    (is (thrown-with-msg? Exception #"refeicao ja existe: 1478fa0b-d996-489e-a1f0-649b0d28d7ee" (:processed (controller.refeicoes/create-refeicao refeicao-teste)))))
+    (with-redefs [db.refeicoes/get (fn [clauses] (mock.refeicoes/mock-db-refeicoes-get clauses))
+                  db.refeicoes/insert! (fn [refeicao-builder] (mock.refeicoes/mock-db-refeicoes-get-for-insert refeicao-builder))]
+      (is (thrown-with-msg? Exception #"refeicao ja existe: 1478fa0b-d996-489e-a1f0-649b0d28d7ee" (:processed (controller.refeicoes/create-refeicao refeicao-teste))))))
     
   (testing "should update a refeicao"
-    (let [result (controller.refeicoes/update-refeicao (:uuid refeicao-teste) {:descricao "refeicao teste unitario update"})]
-      (is (= (count result) 1))
-      (is (= (:descricao (first result)) "refeicao teste unitario update"))))
+    (with-redefs [db.refeicoes/get (fn [clauses] (mock.refeicoes/mock-db-refeicoes-get clauses))
+                  db.refeicoes/update! (fn [fields clauses] (mock.refeicoes/mock-db-refeicoes-update! fields clauses))]
+      (let [result (controller.refeicoes/update-refeicao (:uuid refeicao-teste) {:descricao "Refeicao Teste"})]
+        (is (= (count result) 1))
+        (is (= (:descricao (first result)) "Refeicao Teste")))))
   
   (testing "should not update refeicao when it not exists"
-    (is (thrown-with-msg? Exception #"UPDATE - refeicao nao encontrado: 7e827d74-d02b-4371-8b9f-435aefde96d5" (controller.refeicoes/update-refeicao "7e827d74-d02b-4371-8b9f-435aefde96d5" {:descricao "refeicao teste unitario update"}))))
+    (with-redefs [db.refeicoes/get (fn [clauses] (mock.refeicoes/mock-db-refeicoes-get-not-exist clauses))
+                  db.refeicoes/update! (fn [fields clauses] (mock.refeicoes/mock-db-refeicoes-update! fields clauses))]
+    (is (thrown-with-msg? Exception #"UPDATE - refeicao nao encontrado: 7e827d74-d02b-4371-8b9f-435aefde96d5" (controller.refeicoes/update-refeicao "7e827d74-d02b-4371-8b9f-435aefde96d5" {:descricao "refeicao teste unitario update"})))))
     
-  (testing "should not delete a refeicoes by uuid"
-    (is (= (controller.refeicoes/delete-by-uuid (:uuid refeicao-teste)))))
+  (testing "should delete a refeicoes by uuid"
+    (with-redefs [db.refeicoes/get (fn [clauses] (mock.refeicoes/mock-db-refeicoes-get clauses))
+                  db.refeicoes/delete-by-uuid (fn [uuid] (mock.refeicoes/mock-db-refeicoes-delete-by-uuid uuid))
+                  db.pesos-alimentos/delete-by-refeicao (fn [refeicao-uuid] (mock.pesos-alimentos/mock-db-pesos-alimentos-delete-by-refeicao refeicao-uuid))
+                  db.pesos-alimentos/by-refeicao (fn [refeicao-uuid] (mock.pesos-alimentos/mock-db-pesos-alimentos-get-by-refeicao-uuid refeicao-uuid))]
+    (is (= (controller.refeicoes/delete-by-uuid (:uuid refeicao-teste))))))
 
   (testing "should not delete a refeicoes by uuid when it not exists"
-    (is (thrown-with-msg? Exception #"refeicao nao encontrado: 1478fa0b-d996-489e-a1f0-649b0d28d7ee" (:processed (controller.refeicoes/delete-by-uuid (:uuid refeicao-teste)))))))
+    (with-redefs [db.refeicoes/get (fn [clauses] (mock.refeicoes/mock-db-refeicoes-get-not-exist clauses))
+                  db.refeicoes/delete-by-uuid (fn [uuid] (mock.refeicoes/mock-db-refeicoes-delete-by-uuid uuid))
+                  db.pesos-alimentos/delete-by-refeicao (fn [refeicao-uuid] (mock.pesos-alimentos/mock-db-pesos-alimentos-delete-by-refeicao refeicao-uuid))
+                  db.pesos-alimentos/by-refeicao (fn [refeicao-uuid] (mock.pesos-alimentos/mock-db-pesos-alimentos-get-by-refeicao-uuid refeicao-uuid))]
+      (is (thrown-with-msg? Exception #"refeicao nao encontrado: 1478fa0b-d996-489e-a1f0-649b0d28d7ee" (:processed (controller.refeicoes/delete-by-uuid (:uuid refeicao-teste))))))))
 
 (deftest testing-complete-refeicoes
   (testing "should insert a new complete refeicao"
-    (let [result (controller.refeicoes/insert-complete-refeicao complete-refeicao-teste)]
-      (is (= (count result) 2))
-      
-      (let [alimentos (:alimentos result)
-            refeicao (:refeicao result)]
-        (is (= (count alimentos) 4))
-        (is (= (str (:uuid refeicao)) "d6e3ccca-cb0f-4fa4-a0ea-92576407f998"))
-        (is (= (str (utils.dates/str->date (:moment refeicao))) "2021-04-10 12:34:40.0"))
-        (is (= (str (:descricao refeicao)) "Refeicao Teste")))))
+    (with-redefs [db.refeicoes/get (fn [clauses] (mock.refeicoes/mock-db-refeicoes-get-not-exist clauses))
+                  db.refeicoes/insert! (fn [refeicao-builder] (mock.refeicoes/mock-db-refeicoes-get-for-insert refeicao-builder))
+                  db.pesos-alimentos/insert! (fn [peso-alimento] (mock.pesos-alimentos/mock-db-pesos-alimentos-insert! peso-alimento))
+                  db.pesos-alimentos/by-refeicao (fn [refeicao-uuid] (mock.pesos-alimentos/mock-db-pesos-alimentos-get-by-refeicao-uuid-not-exist refeicao-uuid))
+                  controller.pesos-alimentos/create-pesos-alimentos-by-list (fn [pesos-alimentos] (mock.pesos-alimentos/mock-create-peso-alimentos-by-list pesos-alimentos))]
+      (let [result (controller.refeicoes/insert-complete-refeicao complete-refeicao-teste)]
+        (is (= (count result) 2))
+        
+        (let [alimentos (:alimentos result)
+              refeicao (:refeicao result)]
+          (is (= (count alimentos) 4))
+          (is (= (str (:uuid refeicao)) "d6e3ccca-cb0f-4fa4-a0ea-92576407f998"))
+          (is (= (str (utils.dates/str->date (:moment refeicao))) "2021-04-10 12:34:40.0"))
+          (is (= (str (:descricao refeicao)) "Refeicao Teste"))))))
   
   (testing "should get a complete refeicao"
-    (let [result (controller.refeicoes/get-all-refeicoes-by-date-with-calculated-macros "2021-04-10")]
-      (is (= (count result) 1))
-      (is (= (:date (first result)) (utils.dates/str->date "2021-04-10")))
-      
-      (let [calculated-macros (:calculated-macros (first result))
-            refeicoes (:refeicoes (first result))]
-        (is (= (count refeicoes) 4))
-        (is (= (str (:kcal calculated-macros)) "0.033737760000000006"))
-        (is (= (str (:peso calculated-macros)) "570.0")))))
+    (with-redefs [db.refeicoes/get (fn [clauses] (mock.refeicoes/mock-db-refeicoes-get clauses))
+                  db.refeicoes/insert! (fn [refeicao-builder] (mock.refeicoes/mock-db-refeicoes-get-for-insert refeicao-builder))
+                  db.pesos-alimentos/insert! (fn [peso-alimento] (mock.pesos-alimentos/mock-db-pesos-alimentos-insert! peso-alimento))
+                  db.refeicoes/get-all-refeicoes-by-date (fn [date] (mock.refeicoes/mock-db-refeicoes-get-all-refecoes-by-date date))]
+      (let [result (controller.refeicoes/get-all-refeicoes-by-date-with-calculated-macros "2021-04-10")]
+        (is (= (count result) 1))
+        (is (= (:date (first result)) (utils.dates/str->date "2021-04-10")))
+        
+        (let [calculated-macros (:calculated-macros (first result))
+              refeicoes (:refeicoes (first result))]
+          (is (= (count refeicoes) 4))
+          (is (= (str (:kcal calculated-macros)) "1.4582433600000002"))
+          (is (= (str (:peso calculated-macros)) "950.0"))))))
 
-  (testing "shoul delete a refeicao and yours pesos-alimentos by refeicao-uuid"
-    (is (= (controller.refeicoes/delete-by-uuid "d6e3ccca-cb0f-4fa4-a0ea-92576407f998")))))
-
-(deftest testing-alimentos
-  (testing "should create a alimento"
-    (let [alimento (controller.alimentos/create-alimento alimento-teste)]
-      (is (= (count alimento) 1))))
-      
-  (testing "should not create a alimento when if not exists"
-    (is (thrown-with-msg? Exception #"alimento ja existe: 31dbcee6-9e58-4ee8-ab52-d0d2e5d9d3d8" (:processed (controller.alimentos/create-alimento alimento-teste)))))
-          
-  (testing "should update a alimento"
-    (let [result (controller.alimentos/update-alimento (:uuid alimento-teste) {:nome "alimento teste update" :qtde-carboidrato 0.555 :qtde-gorduras 0.222 :qtde-proteinas 0.1})]
-      (is (= (count result) 1))
-      (is (= (:nome (first result)) "alimento teste update"))
-      (is (= (:qtde-carboidrato (first result))  0.555))
-      (is (= (:qtde-gordduras (first result)) 0.222))
-      (is (= (:qtde-proteinas (first result)) 0.1))))
-
-  (testing "should not update alimento when it not exists"
-    (is (thrown-with-msg? Exception #"UPDATE - alimento nao encontrado: d9619362-b603-4b2f-8c9c-9ff5f2c70478" 
-                          (controller.alimentos/update-alimento "d9619362-b603-4b2f-8c9c-9ff5f2c70478" 
-                                                                {:nome "alimento teste update" :qtde-carboidrato 0.555 :qtde-gorduras 0.222 :qtde-proteinas 0.1}))))
-
-  (testing "should not delete a alimento by uuid"
-    (is (= (controller.alimentos/delete-by-uuid (:uuid alimento-teste)))))
-
-  (testing "should not delete a alimento by uuid when it not exists"
-    (is (thrown-with-msg? Exception #"alimento nao encontrado: 31dbcee6-9e58-4ee8-ab52-d0d2e5d9d3d8" (:processed (controller.alimentos/delete-by-uuid (:uuid alimento-teste)))))))
+  (testing "should delete a refeicao and yours pesos-alimentos by refeicao-uuid"
+    (with-redefs [db.refeicoes/get (fn [clauses] (mock.refeicoes/mock-db-refeicoes-get clauses))
+                  db.refeicoes/delete-by-uuid (fn [uuid] (mock.refeicoes/mock-db-refeicoes-delete-by-uuid uuid))
+                  db.pesos-alimentos/delete-by-refeicao (fn [refeicao-uuid] (mock.pesos-alimentos/mock-db-pesos-alimentos-delete-by-refeicao refeicao-uuid))
+                  db.pesos-alimentos/by-refeicao (fn [refeicao-uuid] (mock.pesos-alimentos/mock-db-pesos-alimentos-get-by-refeicao-uuid refeicao-uuid))]
+      (is (= (controller.refeicoes/delete-by-uuid "d6e3ccca-cb0f-4fa4-a0ea-92576407f998"))))))

--- a/test/cadastro_alimentar/handler_test.clj
+++ b/test/cadastro_alimentar/handler_test.clj
@@ -3,16 +3,25 @@
             [ring.mock.request :as mock]
             [cheshire.core :as json]
             [cadastro-alimentar.handler :refer :all]
-            [cadastro-alimentar.utils.dates :as utils.dates]))
+            [cadastro-alimentar.utils.dates :as utils.dates]
+            [cadastro-alimentar.mocks.alimentos :as mock.alimentos]
+            [cadastro-alimentar.db.alimentos :as db.alimentos]
+            [cadastro-alimentar.db.refeicoes :as db.refeicoes]
+            [cadastro-alimentar.mocks.refeicoes :as mock.refeicoes]
+            [cadastro-alimentar.db.tipos-alimentos :as db.tipos-alimentos]
+            [cadastro-alimentar.mocks.tipos-alimentos :as mock.tipos-alimentos]
+            [cadastro-alimentar.db.pesos-alimentos :as db.pesos-alimentos]
+            [cadastro-alimentar.mocks.pesos-alimentos :as mock.pesos-alimentos]
+            [cadastro-alimentar.controller.pesos-alimentos :as controller.pesos-alimentos]))
 
 (def tipo-alimento-teste {:uuid "a3770a85-eb2a-4994-8502-fa8ebaea9fa3" :descricao "Alimento Teste"})
 (def alimento-teste {:uuid "ada049ae-e92c-4795-b359-c84345ffa1bb" :nome "Alimento Teste Cozido" :peso 1.0 :qtde-carboidrato 0.281 :qtde-gorduras 0.002	:qtde-proteinas 0.025	:tipo-alimento-uuid "f1fd8177-d95c-47e7-ae69-6ad6ec8f48c2"})
 
 (def complete-refeicao-teste {:alimentos (list {:uuid "1864c9a4-2dac-48d6-9a9f-12cc91b1cb50" :peso 150.0}
-                                               {:uuid "057df894-5727-4789-898b-b4bcfe07e5d5" :peso 150.0}
-                                               {:uuid "54b9ba0d-4429-4ffa-9298-e242ec3c79d4" :peso 170.0}
-                                               {:uuid "e3265510-87da-4a88-a610-ea18620e7802" :peso 100.0})
-                                               :refeicao {:uuid "d6e3ccca-cb0f-4fa4-a0ea-92576407f998" :moment "2021-04-10T15:34:40Z" :descricao "Refeicao Teste Handler"}})
+                                                {:uuid "057df894-5727-4789-898b-b4bcfe07e5d5" :peso 150.0}
+                                                {:uuid "54b9ba0d-4429-4ffa-9298-e242ec3c79d4" :peso 170.0}
+                                                {:uuid "e3265510-87da-4a88-a610-ea18620e7802" :peso 100.0})
+                                                :refeicao {:uuid "d6e3ccca-cb0f-4fa4-a0ea-92576407f998" :moment "2021-04-10T15:34:40Z" :descricao "Refeicao Teste Handler"}})
 
 (deftest handler-test
   (testing "testing main route (invlid)")
@@ -26,228 +35,230 @@
 
 (deftest alimentos-test
   (testing "testing get all"
-    (let [response (app (mock/request :get "/api/alimentos"))
-          body (json/parse-string (:body response) #(keyword %))
-          alimento (first body)]
-      (is (= (:status response) 200))
-      (is (> (count body) 0))
-      (is (not (empty? (:nome alimento))))
-      (is (not (empty? (:tipo-alimento-descricao alimento))))))
+    (with-redefs [db.alimentos/get (fn [clauses] (mock.alimentos/mock-db-alimentos-get clauses))]
+      (let [response (app (mock/request :get "/api/alimentos"))
+      body (json/parse-string (:body response) #(keyword %))
+      alimento (first body)]
+  (is (= (:status response) 200))
+  (is (> (count body) 0))
+  (is (not (empty? (:nome alimento))))
+  (is (not (empty? (:tipo-alimento-descricao alimento)))))))
+
     
-  (testing "testing geting alimento with by uuid 1864c9a4-2dac-48d6-9a9f-12cc91b1cb50"
-    (let [response (app (mock/request :get "/api/alimentos/1864c9a4-2dac-48d6-9a9f-12cc91b1cb50"))
-          body (json/parse-string (:body response) #(keyword %))
-          alimento (first body)]
-      (is (= (:status response) 200))
-      (is (= (count body) 1))
-      (is (= (:uuid alimento) "1864c9a4-2dac-48d6-9a9f-12cc91b1cb50"))
-      (is (= (:nome alimento) "Arroz Branco Cozido"))
-      (is (= (:tipo-alimento-descricao alimento) "Grão/Cereal"))))
+  (testing "testing geting alimento with by uuid informed"
+    (with-redefs [db.alimentos/get (fn [clauses] (mock.alimentos/mock-db-alimentos-get clauses))]
+      (let [response (app (mock/request :get "/api/alimentos/ff272397-2999-4896-9dda-4545c5ab4f33"))
+            body (json/parse-string (:body response) #(keyword %))
+            alimento (first body)]
+        (is (= (:status response) 200))
+        (is (= (count body) 1))
+        (is (= (:uuid alimento) "ff272397-2999-4896-9dda-4545c5ab4f33"))
+        (is (= (:nome alimento) "Alimento Teste Mockado"))
+        (is (= (:tipo-alimento-descricao alimento) "Alimento Teste")))))
 
   (testing "not-found status when inform not exist uuid"
-    (let [response (app (mock/request :get "/api/alimentos/d0659c2d-3564-484f-8ed7-b4f4bd6c9161"))]
-      (is (= (:status response) 404))))
-  
+    (with-redefs [db.alimentos/get (fn [clauses] (mock.alimentos/mock-db-alimentos-get-not-exist clauses))]
+      (let [response (app (mock/request :get "/api/alimentos/d0659c2d-3564-484f-8ed7-b4f4bd6c9161"))]
+        (is (= (:status response) 404)))))
+
   (testing "insert a alimento"
-    (let [response (app (-> (mock/request :post "/api/alimentos")
-              (mock/json-body alimento-teste)
+    (with-redefs [db.alimentos/get (fn [clauses] (mock.alimentos/mock-db-alimentos-get-for-insert clauses))
+                  db.alimentos/insert! (fn [alimento] (mock.alimentos/mock-db-alimentos-insert! alimento))]
+      (let [response (app (-> (mock/request :post "/api/alimentos")
+                              (mock/json-body alimento-teste)
               ;(mock/body (json/generate-string tipo-alimento-teste))
-              (mock/content-type "application/json")
-              (mock/header "Accept" "application/json")))
-          body (json/parse-string (:body response) #(keyword %))]
-          (is (= (:status response) 200))
-          (is (= (str  (:uuid (first body))) "ada049ae-e92c-4795-b359-c84345ffa1bb"))
-          (is (= (:nome (first body)) "Alimento Teste Cozido"))
-          (is (= (:peso (first body)) 1.0))
-          (is (= (:qtde-carboidrato (first body)) 0.281))
-          (is (= (:qtde-gorduras (first body)) 0.002))
-          (is (= (:qtde-proteinas (first body)) 0.025))
-          (is (= (str (:tipo-alimento-uuid (first body))) "f1fd8177-d95c-47e7-ae69-6ad6ec8f48c2"))))
+                              (mock/content-type "application/json")
+                              (mock/header "Accept" "application/json")))
+            body (json/parse-string (:body response) #(keyword %))]
+        (is (= (:status response) 200))
+        (is (= (str  (:uuid (first body))) "ada049ae-e92c-4795-b359-c84345ffa1bb"))
+        (is (= (:nome (first body)) "Alimento Teste Cozido"))
+        (is (= (:peso (first body)) 1.0))
+        (is (= (:qtde-carboidrato (first body)) 0.281))
+        (is (= (:qtde-gorduras (first body)) 0.002))
+        (is (= (:qtde-proteinas (first body)) 0.025))
+        (is (= (str (:tipo-alimento-uuid (first body))) "f1fd8177-d95c-47e7-ae69-6ad6ec8f48c2")))))
 
   (testing "Not insert a alimento when it exists"
-    (let [response (app (-> (mock/request :post "/api/alimentos")
-                            (mock/json-body alimento-teste)
+    (with-redefs [db.alimentos/get (fn [clauses] (mock.alimentos/mock-db-alimentos-get clauses))
+                  db.alimentos/insert! (fn [alimento] (mock.alimentos/mock-db-alimentos-insert! alimento))]
+      (let [response (app (-> (mock/request :post "/api/alimentos")
+                              (mock/json-body alimento-teste)
                             ;(mock/body (json/generate-string tipo-alimento-teste))
-                            (mock/content-type "application/json")
-                            (mock/header "Accept" "application/json")))]
-      (is (= (:status response) 409))))
+                              (mock/content-type "application/json")
+                              (mock/header "Accept" "application/json")))]
+        (is (= (:status response) 409)))))
 
   (testing "update a alimento"
-    (let [response (app (-> (mock/request :put "/api/alimentos/ada049ae-e92c-4795-b359-c84345ffa1bb")
-                            (mock/json-body {:nome "Alimento Cozido Teste Update" :qtde-proteinas 0.5 :tipo-alimento-uuid "5e684cd9-ab77-4bcb-96f5-a3e46d82c454"})
+    (with-redefs [db.alimentos/get (fn [clauses] (mock.alimentos/mock-db-alimentos-get-for-update clauses))
+                  db.alimentos/update! (fn [fields clauses] (mock.alimentos/mock-db-alimentos-update! fields clauses))]
+      (let [response (app (-> (mock/request :put "/api/alimentos/ada049ae-e92c-4795-b359-c84345ffa1bb")
+                              (mock/json-body {:nome "Alimento Cozido Teste Update" :qtde-proteinas 0.5 :tipo-alimento-uuid "5e684cd9-ab77-4bcb-96f5-a3e46d82c454"})
                             ;(mock/body (json/generate-string tipo-alimento-teste))
-                            (mock/content-type "application/json")
-                            (mock/header "Accept" "application/json")))
-          body (json/parse-string (:body response) #(keyword %))]
-      (is (= (:status response) 200))
-      (is (= (:nome (first body)) "Alimento Cozido Teste Update"))
-      (is (= (:qtde-proteinas (first body)) 0.5))
-      (is (= (str (:tipo-alimento-uuid (first body))) "5e684cd9-ab77-4bcb-96f5-a3e46d82c454")))) ;a400f357-0ab9-4819-9c82-1280d150e1de
-  
-  (testing "delete a tipo-alimento by uuid"
-    (let [response (app (-> (mock/request :delete "/api/alimentos/ada049ae-e92c-4795-b359-c84345ffa1bb")
-                            (mock/content-type "application/json")
-                            (mock/header "Accept" "application/json")))]
-      (is (= (:status response) 200))))
+                              (mock/content-type "application/json")
+                              (mock/header "Accept" "application/json")))
+            body (json/parse-string (:body response) #(keyword %))]
+        (is (= (:status response) 200))
+        (is (= (:nome (first body)) "Alimento Cozido Teste Update"))
+        (is (= (:qtde-proteinas (first body)) 0.5))
+        (is (= (str (:tipo-alimento-uuid (first body))) "5e684cd9-ab77-4bcb-96f5-a3e46d82c454"))))) ;a400f357-0ab9-4819-9c82-1280d150e1de
 
-  (testing "not update a tipo-alimento when it not exissts"
-    (let [response (app (-> (mock/request :put "/api/alimentos/a3770a85-eb2a-4994-8502-fa8ebaea9fa3")
-                            (mock/json-body {:nome "Alimento Cozido Teste Update" :qtde-proteinas 0.5 :tipo-alimento-uuid "5e684cd9-ab77-4bcb-96f5-a3e46d82c454"})
+  (testing "delete a alimento by uuid"
+    (with-redefs [db.alimentos/get (fn [clauses] (mock.alimentos/mock-db-alimentos-get clauses))
+                  db.alimentos/delete-by-uuid (fn [alimento-uuid] (mock.alimentos/mock-db-alimentos-delete-by-uuid alimento-uuid))]
+      (let [response (app (-> (mock/request :delete "/api/alimentos/ada049ae-e92c-4795-b359-c84345ffa1bb")
+                              (mock/content-type "application/json")
+                              (mock/header "Accept" "application/json")))]
+        (is (= (:status response) 200)))))
+
+  (testing "not update a alimento when it not exissts"
+    (with-redefs [db.alimentos/get (fn [clauses] (mock.alimentos/mock-db-alimentos-get-for-update-not-exist clauses))
+                  db.alimentos/update! (fn [fields clauses] (mock.alimentos/mock-db-alimentos-update! fields clauses))]
+      (let [response (app (-> (mock/request :put "/api/alimentos/a3770a85-eb2a-4994-8502-fa8ebaea9fa3")
+                              (mock/json-body {:nome "Alimento Cozido Teste Update" :qtde-proteinas 0.5 :tipo-alimento-uuid "5e684cd9-ab77-4bcb-96f5-a3e46d82c454"})
                             ;(mock/body (json/generate-string tipo-alimento-teste))
-                            (mock/content-type "application/json")
-                            (mock/header "Accept" "application/json")))]
-      (is (= (:status response) 204))))
+                              (mock/content-type "application/json")
+                              (mock/header "Accept" "application/json")))]
+        (is (= (:status response) 204)))))
 
-  (testing "not delete a tipo-alimento by uuid when it nos exists"
-    (let [response (app (-> (mock/request :delete "/api/alimentos/a3770a85-eb2a-4994-8502-fa8ebaea9fa3")
-                            (mock/content-type "application/json")
-                            (mock/header "Accept" "application/json")))]
-      (is (= (:status response) 404))))      
-  
-  (testing "invalid route"
-    (let [response (app (mock/request :get "/api/alimentos/invalid"))]
-      (is (= (:status response) 400)))))
-    
+  (testing "not delete a alimento by uuid when it nos exists"
+    (with-redefs [db.alimentos/get (fn [clauses] (mock.alimentos/mock-db-alimentos-get-for-delete-not-exist clauses))
+                  db.alimentos/delete-by-uuid (fn [alimento-uuid] (mock.alimentos/mock-db-alimentos-delete-by-uuid alimento-uuid))]
+      (let [response (app (-> (mock/request :delete "/api/alimentos/a3770a85-eb2a-4994-8502-fa8ebaea9fa3")
+                              (mock/content-type "application/json")
+                              (mock/header "Accept" "application/json")))]
+        (is (= (:status response) 404))))))
+            
 (deftest refeicoes-test
   (testing "testing get all"
-    (let [response (app (mock/request :get "/api/refeicoes"))
-          body (json/parse-string (:body response) #(keyword %))
-          refeicao (first body)]
-      (is (= (:status response) 200))
-      (is (> (count body) 0))
-      (is (not (empty? (:moment refeicao))))))
+    (with-redefs [db.refeicoes/get (fn [clauses] (mock.refeicoes/mock-db-refeicoes-get clauses))]
+      (let [response (app (mock/request :get "/api/refeicoes"))
+            body (json/parse-string (:body response) #(keyword %))
+            refeicao (first body)]
+        (is (= (:status response) 200))
+        (is (> (count body) 0))
+        (is (not (empty? (:moment refeicao)))))))
     
-  (testing "testing geting refeicao with uuid c8a2bfb9-2828-4c70-84ce-b2c3dd3db230"
-    (let [response (app (mock/request :get "/api/refeicoes/c8a2bfb9-2828-4c70-84ce-b2c3dd3db230"))
-          body (json/parse-string (:body response) #(keyword %))
-          refeicao (first body)]
-      (is (= (:status response) 200))
-      (is (= (count body) 1))
-      (is (= (str (:uuid refeicao)) "c8a2bfb9-2828-4c70-84ce-b2c3dd3db230"))
-      (is (= (:moment refeicao) "2020-07-24T15:53:07Z"))))
-
-  (testing "testind get all complete refeicoes information"
-    (let [response (app (mock/request :get "/api/refeicoes/completas/2020-07-24"))
-          body (json/parse-string (:body response) #(keyword %))
-          refeicoes (:refeicoes (first body))
-          calculated-macros (:calculated-macros (first body))]
-      (is (= (:status response) 200))
-      (is (= (count refeicoes) 5))
-      (is (= (:kcal calculated-macros) 2.9097633600000004))
-      (is (= (:peso calculated-macros)  1000.0))))
+  (testing "testing geting refeicao with uuid infomed"
+    (with-redefs [db.refeicoes/get (fn [clauses] (mock.refeicoes/mock-db-refeicoes-get clauses))]
+      (let [response (app (mock/request :get "/api/refeicoes/c8a2bfb9-2828-4c70-84ce-b2c3dd3db230"))
+            body (json/parse-string (:body response) #(keyword %))
+            refeicao (first body)]
+        (is (= (:status response) 200))
+        (is (= (count body) 1))
+        (is (= (str (:uuid refeicao)) "c8a2bfb9-2828-4c70-84ce-b2c3dd3db230"))
+        (is (= (:moment refeicao) "2020-07-24T15:53:07Z")))))
 
   (testing "not-found status when inform not exist uuid"
-    (let [response (app (mock/request :get "/api/refeicoes/38200d40-c29c-488f-acb9-6ef183989672"))]
-      (is (= (:status response) 404))))
-      
-  (testing "invalid route"
-    (let [response (app (mock/request :get "/api/refeicoes/invalid"))]
-      (is (= (:status response) 400)))))
+    (with-redefs [db.refeicoes/get (fn [clauses] (mock.refeicoes/mock-db-refeicoes-get-not-exist clauses))]
+      (let [response (app (mock/request :get "/api/refeicoes/38200d40-c29c-488f-acb9-6ef183989672"))]
+        (is (= (:status response) 404))))))
 
 (deftest complete-refeicao
   (testing "insert a new complete refeicao"
-    (let [response (app (-> (mock/request :post "/api/refeicoes/completas")
-              (mock/json-body complete-refeicao-teste)
-              ;(mock/body (json/generate-string tipo-alimento-teste))
-              (mock/content-type "application/json")
-              (mock/header "Accept" "application/json")))
-          body (json/parse-string (:body response) #(keyword %))]
-      (is (= (count body) 2))
+    (with-redefs [db.refeicoes/get (fn [clauses] (mock.refeicoes/mock-db-refeicoes-get-not-exist clauses))
+                  db.refeicoes/insert! (fn [refeicao-builder] (mock.refeicoes/mock-db-refeicoes-get-for-insert refeicao-builder))
+                  db.pesos-alimentos/insert! (fn [peso-alimento] (mock.pesos-alimentos/mock-db-pesos-alimentos-insert! peso-alimento))
+                  db.pesos-alimentos/by-refeicao (fn [refeicao-uuid] (mock.pesos-alimentos/mock-db-pesos-alimentos-get-by-refeicao-uuid-not-exist refeicao-uuid))
+                  controller.pesos-alimentos/create-pesos-alimentos-by-list (fn [pesos-alimentos] (mock.pesos-alimentos/mock-create-peso-alimentos-by-list pesos-alimentos))]
+      (let [response (app (-> (mock/request :post "/api/refeicoes/completas")
+                (mock/json-body complete-refeicao-teste)
+                ;(mock/body (json/generate-string tipo-alimento-teste))
+                (mock/content-type "application/json")
+                (mock/header "Accept" "application/json")))
+            body (json/parse-string (:body response) #(keyword %))]
+        (is (= (count body) 2))
+    
+        (let [alimentos (apply list (:alimentos body))
+              refeicao (:refeicao body)]
+          (is (= (count alimentos) 4))
+          (is (= (str (:uuid refeicao)) "d6e3ccca-cb0f-4fa4-a0ea-92576407f998"))
+          (is (= (str (utils.dates/str->date (:moment refeicao))) "2021-04-10 12:34:40.0"))
+          (is (= (str (:descricao refeicao)) "Refeicao Teste Handler"))))))
   
-      (let [alimentos (apply list (:alimentos body))
-            refeicao (:refeicao body)]
-        (is (= (count alimentos) 4))
-        (is (= (str (:uuid refeicao)) "d6e3ccca-cb0f-4fa4-a0ea-92576407f998"))
-        (is (= (str (utils.dates/str->date (:moment refeicao))) "2021-04-10 12:34:40.0"))
-        (is (= (str (:descricao refeicao)) "Refeicao Teste Handler")))))        
-  
-    (testing "testind get all complete refeicoes information"
-      (let [response (app (mock/request :get "/api/refeicoes/completas/2021-04-10"))
-            body (json/parse-string (:body response) #(keyword %))
-            refeicoes (:refeicoes (first body))
-            calculated-macros (:calculated-macros (first body))]
-        (is (= (:status response) 200))
-        (is (= (count refeicoes) 4))
-        (is (= (:kcal calculated-macros) 0.033737760000000006))
-        (is (= (:peso calculated-macros) 570.0))))
+    (testing "testing get all complete refeicoes information"
+      (with-redefs [db.refeicoes/get (fn [clauses] (mock.refeicoes/mock-db-refeicoes-get clauses))
+                    db.refeicoes/insert! (fn [refeicao-builder] (mock.refeicoes/mock-db-refeicoes-get-for-insert refeicao-builder))
+                    db.pesos-alimentos/insert! (fn [peso-alimento] (mock.pesos-alimentos/mock-db-pesos-alimentos-insert! peso-alimento))
+                    db.refeicoes/get-all-refeicoes-by-date (fn [date] (mock.refeicoes/mock-db-refeicoes-get-all-refecoes-by-date date))]
+        (let [response (app (mock/request :get "/api/refeicoes/completas/2021-04-10"))
+              body (json/parse-string (:body response) #(keyword %))
+              refeicoes (:refeicoes (first body))
+              calculated-macros (:calculated-macros (first body))]
+          (is (= (:status response) 200))
+          (is (= (count refeicoes) 4))
+          (is (= (:kcal calculated-macros) 1.4582433600000002))
+          (is (= (:peso calculated-macros) 950.0)))))
 
     (testing "delete a complete refeicao by refeicao-uuid"
+      (with-redefs [db.pesos-alimentos/delete-by-refeicao (fn [refeicao-uuid] (mock.pesos-alimentos/mock-db-pesos-alimentos-delete-by-refeicao refeicao-uuid))
+                    db.pesos-alimentos/by-refeicao (fn [refeicao-uuid] (mock.pesos-alimentos/mock-db-pesos-alimentos-get-by-refeicao-uuid refeicao-uuid))
+                    db.refeicoes/delete-by-uuid (fn [refeicao-uuid] (mock.refeicoes/mock-db-refeicoes-delete-by-uuid refeicao-uuid))
+                    db.refeicoes/get (fn [clauses] (mock.refeicoes/mock-db-refeicoes-get clauses))]
       (let [response (app (-> (mock/request :delete "/api/refeicoes/completas/d6e3ccca-cb0f-4fa4-a0ea-92576407f998")
                             (mock/content-type "application/json")
                             (mock/header "Accept" "application/json")))]
-      (is (= (:status response) 200)))))
+      (is (= (:status response) 200))))))
 
 (deftest tipos-alimento-test
   (testing "testing get all"
-    (let [response (app (mock/request :get "/api/tipos_alimentos"))
-          body (json/parse-string (:body response) #(keyword %))
-          tipo-alimento (first body)]
-      (is (= (:status response) 200))
-      (is (> (count body) 0))
-      (is (not (empty? (:descricao tipo-alimento))))))
+    (with-redefs [db.tipos-alimentos/get (fn [clauses] (mock.tipos-alimentos/mock-db-tipos-alimentos-get clauses))]
+      (let [response (app (mock/request :get "/api/tipos_alimentos"))
+            body (json/parse-string (:body response) #(keyword %))
+            tipo-alimento (first body)]
+        (is (= (:status response) 200))
+        (is (> (count body) 0))
+        (is (not (empty? (:descricao tipo-alimento)))))))
     
-  (testing "testing geting refeicao with uuid c4b96964-60fe-4e82-be05-ee38a555cde0"
-    (let [response (app (mock/request :get "/api/tipos_alimentos/c4b96964-60fe-4e82-be05-ee38a555cde0"))
-          body (json/parse-string (:body response) #(keyword %))
-          tipo-alimento (first body)]
-      (is (= (:status response) 200))
-      (is (= (count body) 1))
-      (is (= (:uuid tipo-alimento) "c4b96964-60fe-4e82-be05-ee38a555cde0"))
-      (is (= (:descricao tipo-alimento) "Carne Bovina"))))
+  (testing "testing geting refeicao with uuid informed"
+    (with-redefs [db.tipos-alimentos/get (fn [clauses] (mock.tipos-alimentos/mock-db-tipos-alimentos-get clauses))]
+      (let [response (app (mock/request :get "/api/tipos_alimentos/a3770a85-eb2a-4994-8502-fa8ebaea9fa3"))
+            body (json/parse-string (:body response) #(keyword %))
+            tipo-alimento (first body)]
+        (is (= (:status response) 200))
+        (is (= (count body) 1))
+        (is (= (:uuid tipo-alimento) "a3770a85-eb2a-4994-8502-fa8ebaea9fa3"))
+        (is (= (:descricao tipo-alimento) "Alimento Teste")))))
 
-  (testing "not-found status when inform not exist uuid"
-    (let [response (app (mock/request :get "/api/tipos_alimentos/13dde849-a5a5-473e-b74e-5543a7de83a1"))]
-      (is (= (:status response) 404))))
+  (testing "not-found status when inform an not exist uuid"
+    (with-redefs [db.tipos-alimentos/get (fn [clauses] (mock.tipos-alimentos/mock-db-tipos-alimentos-get-not-exist clauses))]
+      (let [response (app (mock/request :get "/api/tipos_alimentos/13dde849-a5a5-473e-b74e-5543a7de83a1"))]
+        (is (= (:status response) 404)))))
 
   (testing "insert a tipo-alimento"
-    (let [response (app (-> (mock/request :post "/api/tipos_alimentos")
-                            (mock/json-body tipo-alimento-teste)
+    (with-redefs [db.tipos-alimentos/get (fn [clauses] (mock.tipos-alimentos/mock-db-alimentipos-alimentos-get-for-insert clauses))
+                  db.tipos-alimentos/insert! (fn [tipo-alimento] (mock.tipos-alimentos/mock-db-tipos-alimentos-insert! tipo-alimento))]
+      (let [response (app (-> (mock/request :post "/api/tipos_alimentos")
+                              (mock/json-body tipo-alimento-teste)
                             ;(mock/body (json/generate-string tipo-alimento-teste))
-                            (mock/content-type "application/json")
-                            (mock/header "Accept" "application/json")))
-          body (json/parse-string (:body response) #(keyword %))]
-      (is (= (:status response) 200))
-      (is (= (str  (:uuid (first body))) "a3770a85-eb2a-4994-8502-fa8ebaea9fa3"))
-      (is (= (:descricao (first body)) "Alimento Teste"))))
+                              (mock/content-type "application/json")
+                              (mock/header "Accept" "application/json")))
+            body (json/parse-string (:body response) #(keyword %))]
+        (is (= (:status response) 200))
+        (is (= (str  (:uuid (first body))) "a3770a85-eb2a-4994-8502-fa8ebaea9fa3"))
+        (is (= (:descricao (first body)) "Alimento Teste")))))
 
   (testing "Not insert a tipo-alimento when it exists"
-    (let [response (app (-> (mock/request :post "/api/tipos_alimentos")
-                            (mock/json-body tipo-alimento-teste)
+    (with-redefs [db.tipos-alimentos/get (fn [clauses] (mock.tipos-alimentos/mock-db-tipos-alimentos-get clauses))
+                  db.tipos-alimentos/insert! (fn [tipo-alimento] (mock.tipos-alimentos/mock-db-tipos-alimentos-insert! tipo-alimento))]
+      (let [response (app (-> (mock/request :post "/api/tipos_alimentos")
+                              (mock/json-body tipo-alimento-teste)
                             ;(mock/body (json/generate-string tipo-alimento-teste))
-                            (mock/content-type "application/json")
-                            (mock/header "Accept" "application/json")))]
-      (is (= (:status response) 409))))
+                              (mock/content-type "application/json")
+                              (mock/header "Accept" "application/json")))]
+        (is (= (:status response) 409)))))
 
   (testing "update a tipo-alimento"
-    (let [response (app (-> (mock/request :put "/api/tipos_alimentos/a3770a85-eb2a-4994-8502-fa8ebaea9fa3")
-                            (mock/json-body {:descricao "Tipo Alimento Update"})
+    (with-redefs [db.tipos-alimentos/get (fn [clauses] (mock.tipos-alimentos/mock-db-tipos-alimentos-get-for-update clauses))
+                  db.tipos-alimentos/update! (fn [fields clauses] (mock.tipos-alimentos/mock-db-tipos-alimentos-update! fields clauses))]
+      (let [response (app (-> (mock/request :put "/api/tipos_alimentos/a3770a85-eb2a-4994-8502-fa8ebaea9fa3")
+                              (mock/json-body {:descricao "Tipo Alimento Update"})
                             ;(mock/body (json/generate-string tipo-alimento-teste))
-                            (mock/content-type "application/json")
-                            (mock/header "Accept" "application/json")))
-          body (json/parse-string (:body response) #(keyword %))]
-      (is (= (:status response) 200))
-      (is (= (:descricao (first body)) "Tipo Alimento Update"))))
+                              (mock/content-type "application/json")
+                              (mock/header "Accept" "application/json")))
+            body (json/parse-string (:body response) #(keyword %))]
+        (is (= (:status response) 200))
+        (is (= (:descricao (first body)) "Tipo Alimento Update")))))
   
-  (testing "delete a tipo-alimento by uuid"
-    (let [response (app (-> (mock/request :delete "/api/tipos_alimentos/a3770a85-eb2a-4994-8502-fa8ebaea9fa3")
-                            (mock/content-type "application/json")
-                            (mock/header "Accept" "application/json")))]
-      (is (= (:status response) 200))))
-
-  (testing "not update a tipo-alimento when it not exissts"
-    (let [response (app (-> (mock/request :put "/api/tipos_alimentos/a3770a85-eb2a-4994-8502-fa8ebaea9fa3")
-                            (mock/json-body {:descricao "Tipo Alimento Update"})
-                            ;(mock/body (json/generate-string tipo-alimento-teste))
-                            (mock/content-type "application/json")
-                            (mock/header "Accept" "application/json")))]
-      (is (= (:status response) 204))))
-
-  (testing "not delete a tipo-alimento by uuid when it nos exists"
-    (let [response (app (-> (mock/request :delete "/api/tipos_alimentos/a3770a85-eb2a-4994-8502-fa8ebaea9fa3")
-                            (mock/content-type "application/json")
-                            (mock/header "Accept" "application/json")))]
-      (is (= (:status response) 404))))
-      
-  (testing "invalid route"
-    (let [response (app (mock/request :get "/api/tipos_alimentos/invalid"))]
-      (is (= (:status response) 400)))))
+ )
+ 


### PR DESCRIPTION
* mokando banco de dados nos teste dos alimentos

* refatorando os mocks e mockando os acessos ao banco do tipos-alimentos e refeicões

* mockando o acesso ao banco de dados de peso-alimento e dando inicio aos mocks de refeicao-completa

* finalizando o acerto dos mocks no teste cadastro-alimentar.handler-test

* criando mocks para refeicoes-completas

* corrigindo o mock de refeicoes-test que alterei errado

* fazendo correções no mock de testes da api

* finalizando o mock do controller-test

Co-authored-by: Rodrigo Vanhoz Ribeiro <rodrigo.vanhoz@@gmail.com>